### PR TITLE
Proposed feature addition to git-parameter plugin for Jenkins

### DIFF
--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -44,8 +44,8 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 
 	public static final String PARAMETER_TYPE_TAG = "PT_TAG";
 	public static final String PARAMETER_TYPE_REVISION = "PT_REVISION";
-        
-        private final UUID uuid;
+
+	private final UUID uuid;
 
 	@Extension
 	public static class DescriptorImpl extends ParameterDescriptor {
@@ -55,44 +55,39 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 		}
 	}
 
-              
+
 	private String type;
-        private String branch;
-        private String tagFilter;
-        private String tagPartSplitter;
-        
-        private String errorMessage;        
+	private String branch;
+	private String tagFilter;
+	private boolean useSmartNumberSort;
+
+	private String errorMessage;        
 	private String defaultValue;        
-        
-        private Map<String, String> revisionMap;
-        private Map<String, String> tagMap;
+
+	private Map<String, String> revisionMap;
+	private Map<String, String> tagMap;
 
 	@DataBoundConstructor
 	public GitParameterDefinition(String name,
-                String type, String defaultValue,
-                String description, String branch,
-                String tagFilter, String tagPartSplitter
-        ) {
+			String type, String defaultValue,
+			String description, String branch,
+			String tagFilter, boolean useSmartNumberSort
+			) {
 		super(name, description);
 		this.type = type;
 		this.defaultValue = defaultValue;
-                this.branch = branch;
-                
-                this.uuid = UUID.randomUUID();               
+		this.branch = branch;
+		this.useSmartNumberSort = useSmartNumberSort;
+		this.uuid = UUID.randomUUID();               
 
-        if (isNullOrWhitespace(tagFilter)) {
-    		this.tagFilter = "*";
-    	} else {
-    		this.tagFilter = tagFilter;
-    	}
-        
-        if (isNullOrWhitespace(tagPartSplitter)) {
-        	this.tagPartSplitter = null;
-        } else {
-        	this.tagPartSplitter = tagPartSplitter;
-        }
+		if (isNullOrWhitespace(tagFilter)) {
+			this.tagFilter = "*";
+		} else {
+			this.tagFilter = tagFilter;
+		}
+
 	}
-        
+
 
 	@Override
 	public ParameterValue createValue(StaplerRequest request) {
@@ -119,10 +114,10 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 				}
 			}
 		}
-                
-                if("".equals(strValue)) {
-                    strValue = defaultValue;
-                }
+
+		if("".equals(strValue)) {
+			strValue = defaultValue;
+		}
 
 		GitParameterValue gitParameterValue = new GitParameterValue(jO.getString("name"), strValue);
 		return gitParameterValue;
@@ -136,47 +131,47 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 		}
 		return super.getDefaultParameterValue();
 	}
-        
-  
-    @Override
+
+
+	@Override
 	public String getType() {
 		return type;
 	}
-    
-        
-	public void setType(String type) {
-            if(type.equals(PARAMETER_TYPE_TAG) || type.equals(PARAMETER_TYPE_REVISION) ) {
-		this.type = type;
-            } else {
-                this.errorMessage = "wrongType";
-                
-            }
-	}
-        
-        public String getBranch() {
-                return this.branch;
-        }
-        
-        public void setBranch(String nameOfBranch) {
-                this.branch = nameOfBranch;
-        }
 
-    public String getTagPartSplitter() {
-    	return this.tagPartSplitter;
-    }
-    
-    public void setTagPartSplitter(String tagPartSplitter) {
-    	this.tagPartSplitter = tagPartSplitter;
-    }
-       
-    public String getTagFilter() {
-    	return this.tagFilter;
-    }
-    
-    public void setTagFilter(String tagFilter) {
-    	this.tagFilter = tagFilter;
-    }
-        
+
+	public void setType(String type) {
+		if(type.equals(PARAMETER_TYPE_TAG) || type.equals(PARAMETER_TYPE_REVISION) ) {
+			this.type = type;
+		} else {
+			this.errorMessage = "wrongType";
+
+		}
+	}
+
+	public String getBranch() {
+		return this.branch;
+	}
+
+	public void setBranch(String nameOfBranch) {
+		this.branch = nameOfBranch;
+	}
+
+	public boolean getUseSmartNumberSort() {
+		return this.useSmartNumberSort;
+	}
+
+	public void setUseSmartNumberSort(boolean useSmartNumberSort) {
+		this.useSmartNumberSort = useSmartNumberSort;
+	}
+
+	public String getTagFilter() {
+		return this.tagFilter;
+	}
+
+	public void setTagFilter(String tagFilter) {
+		this.tagFilter = tagFilter;
+	}
+
 	public String getDefaultValue() {
 		return defaultValue;
 	}
@@ -185,217 +180,268 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 		this.defaultValue = defaultValue;
 	}
 
-        
-        public AbstractProject<?,?> getParentProject() {
-            AbstractProject<?,?> context = null;
-            List<AbstractProject> jobs = Hudson.getInstance().getItems(AbstractProject.class);
 
-            for(AbstractProject<?,?> project : jobs) {
-                ParametersDefinitionProperty property = (ParametersDefinitionProperty) project.getProperty(ParametersDefinitionProperty.class);
+	public AbstractProject<?,?> getParentProject() {
+		AbstractProject<?,?> context = null;
+		List<AbstractProject> jobs = Hudson.getInstance().getItems(AbstractProject.class);
 
-                if(property != null) {
-                    List<ParameterDefinition> parameterDefinitions = property.getParameterDefinitions();
+		for(AbstractProject<?,?> project : jobs) {
+			ParametersDefinitionProperty property = (ParametersDefinitionProperty) project.getProperty(ParametersDefinitionProperty.class);
 
-                    if(parameterDefinitions != null) {
-                        for(ParameterDefinition pd : parameterDefinitions) {
+			if(property != null) {
+				List<ParameterDefinition> parameterDefinitions = property.getParameterDefinitions();
 
-                            if(pd instanceof GitParameterDefinition && 
-                                ((GitParameterDefinition) pd).compareTo(this) == 0) {
-                                
-                                context = project;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }  
-            
-            return context;
-        }
-        
-        @Override
-        public int compareTo(GitParameterDefinition pd) {
-            if(pd.uuid.equals(uuid)) {
-                return 0;
-            }
-            
-            return -1;
-        }
-          
-        
-	public void generateContents(String contenttype) {
-            
-          AbstractProject<?,?> project = getParentProject();
-            
-            
-	       // for (AbstractProject<?,?> project : Hudson.getInstance().getItems(AbstractProject.class)) {
-                    if (project.getSomeWorkspace() == null) {
-                        this.errorMessage = "noWorkspace";
-                    }                    
-                    
-                    SCM scm = project.getScm();
-                    
-                    //if (scm instanceof GitSCM); else continue;
-                    if (scm instanceof GitSCM) {
-                        this.errorMessage = "notGit";
-                    }
-                    
-                    
-                    GitSCM git = (GitSCM) scm;
-                    
-                    String defaultGitExe = File.separatorChar != '/' ? "git.exe" : "git";
-                    GitSCM.DescriptorImpl desc = (GitSCM.DescriptorImpl) git.getDescriptor();
-                    if (desc.getOldGitExe() != null) {
-                        defaultGitExe = desc.getOldGitExe();
-                    }
-                    
-                    EnvVars environment = null;
-                    
-                    try {
-                         environment = project.getSomeBuildWithWorkspace().getEnvironment(TaskListener.NULL);
-                    } catch(Exception e) {}
-                    
-                    for (RemoteConfig repository : git.getRepositories()) {
-                        for (URIish remoteURL : repository.getURIs()) {
-                            
-                        IGitAPI newgit = new GitAPI(defaultGitExe, project.getSomeWorkspace(), TaskListener.NULL, environment, new String());
-                      // for later use  
-                //        if(this.branch != null && !this.branch.isEmpty()) {
-                  //          newgit.checkoutBranch(this.branch, null);
-                    //    }
-                        
-                        newgit.fetch();
-                        
-                        if(type.equalsIgnoreCase(PARAMETER_TYPE_REVISION)) {
-                            revisionMap = new HashMap<String, String>();
-                            
-                            
-                        List<ObjectId> oid;   
-                        
-                        if(this.branch != null && !this.branch.isEmpty()) {
-                             oid = newgit.revListBranch(this.branch);                        
-                        } else {
-                             oid = newgit.revListAll();                        
-                        }
-                            
-                                
-                            for(ObjectId noid: oid) {
-                                Revision r = new Revision(noid);
-                                List<String> test3 = newgit.showRevision(r);
-                                String[] authorDate = test3.get(3).split(">");
-                                String author = authorDate[0].replaceFirst("author ", "").replaceFirst("committer ", "") + ">";
-                                String goodDate = null;
-                                try {
-                                 String totmp = authorDate[1].trim().split("\\+")[0].trim();
-                                 long timestamp = Long.parseLong(totmp,10) * 1000;
-                                 Date date = new Date();
-                                 date.setTime(timestamp);
-                                 
-                                 goodDate = new SimpleDateFormat("yyyy:mm:dd").format(date);
+				if(parameterDefinitions != null) {
+					for(ParameterDefinition pd : parameterDefinitions) {
 
-                                 
-                                } catch (Exception e) {
-                                    e.toString();
-                                }
-                                revisionMap.put(r.getSha1String(), r.getSha1String() + " " + author + " " + goodDate);
-                            }
-                        } else if(type.equalsIgnoreCase(PARAMETER_TYPE_TAG)) {         
-                            tagMap = new HashMap<String, String>();
-                             
-                            //Set<String> tagNameList = newgit.getTagNames("*");
-                            Set<String> tagSet = newgit.getTagNames(tagFilter);
-                            ArrayList<String> sortedTagNames = sortTagNames(tagSet, this.tagPartSplitter);
-                            Integer index = 0;
-                            for(String tagName: sortedTagNames) {
-                                tagMap.put(tagName, intToStringWithLeadingZeros(index, 5) + ": " + tagName);
-                                index += 1;
-                            }
-                        }                                
-                            
-                        }
-                    }
-            //     }
-                
+						if(pd instanceof GitParameterDefinition && 
+								((GitParameterDefinition) pd).compareTo(this) == 0) {
+
+							context = project;
+							break;
+						}
+					}
+				}
+			}
+		}  
+
+		return context;
 	}
-        
+
+	@Override
+	public int compareTo(GitParameterDefinition pd) {
+		if(pd.uuid.equals(uuid)) {
+			return 0;
+		}
+
+		return -1;
+	}
+
+
+	public void generateContents(String contenttype) {
+
+		AbstractProject<?,?> project = getParentProject();
+
+
+		// for (AbstractProject<?,?> project : Hudson.getInstance().getItems(AbstractProject.class)) {
+			if (project.getSomeWorkspace() == null) {
+				this.errorMessage = "noWorkspace";
+			}                    
+
+			SCM scm = project.getScm();
+
+			//if (scm instanceof GitSCM); else continue;
+			if (scm instanceof GitSCM) {
+				this.errorMessage = "notGit";
+			}
+
+
+			GitSCM git = (GitSCM) scm;
+
+			String defaultGitExe = File.separatorChar != '/' ? "git.exe" : "git";
+			GitSCM.DescriptorImpl desc = (GitSCM.DescriptorImpl) git.getDescriptor();
+			if (desc.getOldGitExe() != null) {
+				defaultGitExe = desc.getOldGitExe();
+			}
+
+			EnvVars environment = null;
+
+			try {
+				environment = project.getSomeBuildWithWorkspace().getEnvironment(TaskListener.NULL);
+			} catch(Exception e) {}
+
+			for (RemoteConfig repository : git.getRepositories()) {
+				for (URIish remoteURL : repository.getURIs()) {
+
+					IGitAPI newgit = new GitAPI(defaultGitExe, project.getSomeWorkspace(), TaskListener.NULL, environment, new String());
+					// for later use  
+					//        if(this.branch != null && !this.branch.isEmpty()) {
+						//          newgit.checkoutBranch(this.branch, null);
+						//    }
+
+					newgit.fetch();
+
+					if(type.equalsIgnoreCase(PARAMETER_TYPE_REVISION)) {
+						revisionMap = new HashMap<String, String>();
+
+
+						List<ObjectId> oid;   
+
+						if(this.branch != null && !this.branch.isEmpty()) {
+							oid = newgit.revListBranch(this.branch);                        
+						} else {
+							oid = newgit.revListAll();                        
+						}
+
+
+						for(ObjectId noid: oid) {
+							Revision r = new Revision(noid);
+							List<String> test3 = newgit.showRevision(r);
+							String[] authorDate = test3.get(3).split(">");
+							String author = authorDate[0].replaceFirst("author ", "").replaceFirst("committer ", "") + ">";
+							String goodDate = null;
+							try {
+								String totmp = authorDate[1].trim().split("\\+")[0].trim();
+								long timestamp = Long.parseLong(totmp,10) * 1000;
+								Date date = new Date();
+								date.setTime(timestamp);
+
+								goodDate = new SimpleDateFormat("yyyy:mm:dd").format(date);
+
+
+							} catch (Exception e) {
+								e.toString();
+							}
+							revisionMap.put(r.getSha1String(), r.getSha1String() + " " + author + " " + goodDate);
+						}
+					} else if(type.equalsIgnoreCase(PARAMETER_TYPE_TAG)) {         
+						tagMap = new HashMap<String, String>();
+
+						//Set<String> tagNameList = newgit.getTagNames("*");
+						Set<String> tagSet = newgit.getTagNames(tagFilter);
+						ArrayList<String> sortedTagNames = sortTagNames(tagSet, this.tagPartSplitter);
+						Integer index = 0;
+						for(String tagName: sortedTagNames) {
+							tagMap.put(tagName, intToStringWithLeadingZeros(index, 5) + ": " + tagName);
+							index += 1;
+						}
+					}                                
+
+				}
+			}
+			//     }
+
+	}
+
 	private String intToStringWithLeadingZeros(int number, int digits) {
 		assert digits > 0 : "Invalid number of digits";
 
-	    // create variable length array of zeros
-	    char[] zeros = new char[digits];
-	    Arrays.fill(zeros, '0');
-	    // format number as String
-	    DecimalFormat df = new DecimalFormat(String.valueOf(zeros));
+		// create variable length array of zeros
+		char[] zeros = new char[digits];
+		Arrays.fill(zeros, '0');
+		// format number as String
+		DecimalFormat df = new DecimalFormat(String.valueOf(zeros));
 
-	    return df.format(number);
+		return df.format(number);
 	}
-	
-	public ArrayList<String> sortTagNames(Set<String> tagSet, String componentSplitter) {
-		
+
+	public ArrayList<String> sortTagNames(Set<String> tagSet) {
+
 		ArrayList<String> tags = new ArrayList<String>(tagSet);
-		
-		if (componentSplitter == null) {
+
+		if (!this.getUseSmartNumberSort()) {
 			Collections.sort(tags);
 		} else {
-			Collections.sort(tags, new ComponentStringComparer(componentSplitter));
+			Collections.sort(tags, new SmartNumberStringComparer());
 		}
-		
+
 		return tags;
 	}
-	
+
 	public String getErrorMessage() {
-            return errorMessage;
-        }
-        
+		return errorMessage;
+	}
+
 	public Map<String, String> getRevisionMap() {
-            if( revisionMap == null || revisionMap.isEmpty()){
-                generateContents(PARAMETER_TYPE_REVISION);
-            }
-            return revisionMap;
-        }
-        
-        public Map<String, String> getTagMap() {
-            if( tagMap == null || tagMap.isEmpty()){
-                generateContents(PARAMETER_TYPE_TAG);
-            }
-            return tagMap;
-        }
-        
-        private static boolean isNullOrWhitespace(String s) {
-            return s == null || isWhitespace(s);
+		if( revisionMap == null || revisionMap.isEmpty()){
+			generateContents(PARAMETER_TYPE_REVISION);
+		}
+		return revisionMap;
+	}
 
-        }
-        private static boolean isWhitespace(String s) {
-            int length = s.length();
-            for (int i = 0; i < length; i++) {
-                if (!Character.isWhitespace(s.charAt(i))) {
-                    return false;
-                }
-            }
-            return true;
-        }
+	public Map<String, String> getTagMap() {
+		if( tagMap == null || tagMap.isEmpty()){
+			generateContents(PARAMETER_TYPE_TAG);
+		}
+		return tagMap;
+	}
 
-        static class ComponentStringComparer implements Comparator<String> {
-        	
-        	private String splitRegex;
-        	
-        	public ComponentStringComparer(String splitRegex) {
-        		this.splitRegex = splitRegex;
-        	}
-        	
-        	public int compare(String a, String b) {
-				String[] aParts = a.split(this.splitRegex);
-				String[] bParts = b.split(this.splitRegex);
+	private static boolean isNullOrWhitespace(String s) {
+		return s == null || isWhitespace(s);
+
+	}
+	private static boolean isWhitespace(String s) {
+		int length = s.length();
+		for (int i = 0; i < length; i++) {
+			if (!Character.isWhitespace(s.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Compares strings but treats a sequence of digits as a single character.
+	 */
+	static class SmartNumberStringComparer implements Comparator<String> {
+
+		/**
+		 * Gets the token starting at the given index.  It will return the first
+		 * char if it is not a digit, otherwise it will return all consecutive digits
+		 * starting at index.
+		 * @param str The string to extract token from
+		 * @param index The start location
+		 */
+		private String getToken(String str, int index) {
+			char nextChar = str.charAt(index++);
+			String token = String.valueOf(nextChar);
+			
+			// if the first char wasn't a digit then we're already done
+			if (!Character.isDigit(nextChar))
+				return token;
+			
+			// the first char was a digit so continue until end of string or non digit
+			while (index < str.length()) {
+				nextChar = str.charAt(index++);
 				
-				for (int i = 0; i < aParts.length && i < bParts.length; i++) {
-					int difference = aParts[i].compareTo(bParts[i]);
-					if (difference != 0)
-						return difference;
+				if (!Character.isDigit(nextChar))
+					break;
+				
+				token += nextChar;
+			}
+			
+			return token;
+		}
+		
+		/**
+		 * True if the string only contains digits
+		 */
+		private boolean stringContainsInteger(String str) {
+			for (int charIndex = 0; charIndex < str.length(); charIndex++) {
+				if (!Character.isDigit(str.charAt(charIndex)))
+					return false;
+			}
+			return true;
+		}
+		
+		public int compare(String a, String b) {
+			
+			int aIndex = 0;
+			int bIndex = 0;
+			
+			while (aIndex < a.length() && bIndex < b.length()) {
+				String aToken = getToken(a, aIndex);
+				String bToken = getToken(b, bIndex);
+				int difference;
+				
+				if (stringContainsInteger(aToken) && stringContainsInteger(bToken)) {
+					int aInt = Integer.parseInt(aToken);
+					int bInt = Integer.parseInt(bToken);
+					difference = aInt - bInt;
+				} else {
+					difference = aToken.compareTo(bToken);
 				}
 				
-				return new Integer(aParts.length).compareTo(new Integer(bParts.length));
+				if (difference != 0)
+					return difference;
+				
+				aIndex += aToken.length();
+				bIndex += bToken.length();
 			}
-        	
 
-        }
+			return new Integer(a.length()).compareTo(new Integer(b.length()));
+		}
+
+
+	}
 }

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -58,6 +58,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
               
 	private String type;
         private String branch;
+        private String tagFilter;
         
         private String errorMessage;        
 	private String defaultValue;        
@@ -68,7 +69,8 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 	@DataBoundConstructor
 	public GitParameterDefinition(String name,
                 String type, String defaultValue,
-                String description, String branch
+                String description, String branch,
+                String tagFilter
         ) {
 		super(name, description);
 		this.type = type;
@@ -76,6 +78,12 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                 this.branch = branch;
                 
                 this.uuid = UUID.randomUUID();               
+
+    if (isNullOrWhitespace(tagFilter)) {
+      this.tagFilter = "*";
+    } else {
+      this.tagFilter = tagFilter;
+    }
 	}
         
 
@@ -146,6 +154,14 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                 this.branch = nameOfBranch;
         }
 
+    public String getTagFilter() {
+    	return this.tagFilter;
+    }
+    
+    public void setTagFilter(String tagFilter) {
+    	this.tagFilter = tagFilter;
+    }
+        
 	public String getDefaultValue() {
 		return defaultValue;
 	}
@@ -272,7 +288,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                             tagMap = new HashMap<String, String>();
                              
                             //Set<String> tagNameList = newgit.getTagNames("*");
-                            for(String tagName: newgit.getTagNames("*")) {
+                            for(String tagName: newgit.getTagNames(this.tagFilter)) {
                                 tagMap.put(tagName, tagName);
                             }
                         }                                
@@ -301,5 +317,17 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
             return tagMap;
         }
         
+        private static boolean isNullOrWhitespace(String s) {
+            return s == null || isWhitespace(s);
 
+        }
+        private static boolean isWhitespace(String s) {
+            int length = s.length();
+            for (int i = 0; i < length; i++) {
+                if (!Character.isWhitespace(s.charAt(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
 }

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -303,8 +303,10 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                             //Set<String> tagNameList = newgit.getTagNames("*");
                             Set<String> tagSet = newgit.getTagNames(tagFilter);
                             ArrayList<String> sortedTagNames = sortTagNames(tagSet, this.tagPartSplitter);
+                            Integer index = 0;
                             for(String tagName: sortedTagNames) {
-                                tagMap.put(tagName, tagName);
+                                tagMap.put(index.toString(), tagName);
+                                index += 1;
                             }
                         }                                
                             

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -15,8 +15,10 @@ import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 
 import java.io.File;
+import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -305,7 +307,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                             ArrayList<String> sortedTagNames = sortTagNames(tagSet, this.tagPartSplitter);
                             Integer index = 0;
                             for(String tagName: sortedTagNames) {
-                                tagMap.put(index.toString(), tagName);
+                                tagMap.put(tagName, intToStringWithLeadingZeros(index, 5) + ": " + tagName);
                                 index += 1;
                             }
                         }                                
@@ -316,6 +318,18 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
                 
 	}
         
+	private String intToStringWithLeadingZeros(int number, int digits) {
+		assert digits > 0 : "Invalid number of digits";
+
+	    // create variable length array of zeros
+	    char[] zeros = new char[digits];
+	    Arrays.fill(zeros, '0');
+	    // format number as String
+	    DecimalFormat df = new DecimalFormat(String.valueOf(zeros));
+
+	    return df.format(number);
+	}
+	
 	public ArrayList<String> sortTagNames(Set<String> tagSet, String componentSplitter) {
 		
 		ArrayList<String> tags = new ArrayList<String>(tagSet);

--- a/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
+++ b/src/main/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition.java
@@ -15,14 +15,12 @@ import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
 
 import java.io.File;
-import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -262,7 +260,7 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 					newgit.fetch();
 
 					if(type.equalsIgnoreCase(PARAMETER_TYPE_REVISION)) {
-						revisionMap = new HashMap<String, String>();
+						revisionMap = new LinkedHashMap<String, String>();
 
 
 						List<ObjectId> oid;   
@@ -294,15 +292,16 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 							}
 							revisionMap.put(r.getSha1String(), r.getSha1String() + " " + author + " " + goodDate);
 						}
-					} else if(type.equalsIgnoreCase(PARAMETER_TYPE_TAG)) {         
-						tagMap = new HashMap<String, String>();
+					} else if(type.equalsIgnoreCase(PARAMETER_TYPE_TAG)) {   
+						
+						// use a LinkedHashMap so that keys are ordered as inserted
+						tagMap = new LinkedHashMap<String, String>();
 
-						//Set<String> tagNameList = newgit.getTagNames("*");
 						Set<String> tagSet = newgit.getTagNames(tagFilter);
-						ArrayList<String> sortedTagNames = sortTagNames(tagSet, this.tagPartSplitter);
+						ArrayList<String> sortedTagNames = sortTagNames(tagSet);
 						Integer index = 0;
 						for(String tagName: sortedTagNames) {
-							tagMap.put(tagName, intToStringWithLeadingZeros(index, 5) + ": " + tagName);
+							tagMap.put(tagName, tagName);
 							index += 1;
 						}
 					}                                
@@ -311,18 +310,6 @@ public class GitParameterDefinition extends ParameterDefinition implements Compa
 			}
 			//     }
 
-	}
-
-	private String intToStringWithLeadingZeros(int number, int digits) {
-		assert digits > 0 : "Invalid number of digits";
-
-		// create variable length array of zeros
-		char[] zeros = new char[digits];
-		Arrays.fill(zeros, '0');
-		// format number as String
-		DecimalFormat df = new DecimalFormat(String.valueOf(zeros));
-
-		return df.format(number);
 	}
 
 	public ArrayList<String> sortTagNames(Set<String> tagSet) {

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -34,8 +34,8 @@
     <f:textbox />
   </f:entry>
   
-  <f:entry title="Smart number sort" field="useSmartNumberSort">
-    <f:checkbox />
+  <f:entry name="sortMode" title="Tag sort mode" field="sortMode">
+  	<f:enum>${it}</f:enum>
   </f:entry>
 
   <f:entry title="Default Value" field="defaultValue">

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -29,6 +29,10 @@
   <f:entry title="Branch" field="branch">
     <f:textbox />
   </f:entry>
+  
+  <f:entry title="Tag filter" field="tagFilter">
+    <f:textbox />
+  </f:entry>
 
   <f:entry title="Default Value" field="defaultValue">
     <f:textbox />

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -34,8 +34,8 @@
     <f:textbox />
   </f:entry>
   
-  <f:entry title="Tag part splitter" field="tagPartSplitter">
-    <f:textbox />
+  <f:entry title="Smart number sort" field="useSmartNumberSort">
+    <f:checkbox />
   </f:entry>
 
   <f:entry title="Default Value" field="defaultValue">

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/config.jelly
@@ -33,6 +33,10 @@
   <f:entry title="Tag filter" field="tagFilter">
     <f:textbox />
   </f:entry>
+  
+  <f:entry title="Tag part splitter" field="tagPartSplitter">
+    <f:textbox />
+  </f:entry>
 
   <f:entry title="Default Value" field="defaultValue">
     <f:textbox />

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagFilter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagFilter.html
@@ -1,0 +1,3 @@
+<div>
+  Filter pattern passed to "git tag -l &lt;pattern&gt;" command. Leave empty to display all tags.
+</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagPartSplitter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagPartSplitter.html
@@ -1,0 +1,5 @@
+<div>
+    Regular expression used to split up components of the tags for sorting purposes.  For example, if you have version
+    tags that look like v_1.2.3.4 then you would enter the value "\." for this parameter to ensure that the version tags
+    are properly sorted.
+</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagPartSplitter.html
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/help-tagPartSplitter.html
@@ -1,5 +1,0 @@
-<div>
-    Regular expression used to split up components of the tags for sorting purposes.  For example, if you have version
-    tags that look like v_1.2.3.4 then you would enter the value "\." for this parameter to ensure that the version tags
-    are properly sorted.
-</div>

--- a/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
+++ b/src/main/resources/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinition/index.jelly
@@ -9,7 +9,7 @@
             <j:choose>
             	<j:when test="${it.type eq 'PT_TAG'}">
             	    <input type="hidden" name="name" value="${it.name}" />
-                    <select name="value" size="5" width="200px">
+                    <select name="value" size="10" width="300px">
             		<j:forEach var="val" items="${it.tagMap}" >
                             <j:choose>
                                 <option value="${val.key}">${val.value}</option>

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -54,7 +54,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testCreateValue_StaplerRequest() {
         System.out.println("createValue");
               
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch");
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch", "*");
        
         StaplerRequest request = mock(StaplerRequest.class);
         ParameterValue result = instance.createValue(request);
@@ -62,6 +62,30 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         assertEquals(result, new GitParameterValue("name", "defaultValue"));
     }
 
+    @Test
+    public void testConstructorInitializesTagFilterToAsteriskWhenNull() {
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null);
+    	assertEquals("*", instance.getTagFilter());
+    }
+    
+    @Test
+    public void testConstructorInitializesTagFilterToAsteriskWhenWhitespace() {
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ");
+    	assertEquals("*", instance.getTagFilter());
+    }
+    
+    @Test
+    public void testConstructorInitializesTagFilterToAsteriskWhenEmpty() {
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","");
+    	assertEquals("*", instance.getTagFilter());
+    }
+    
+    @Test
+    public void testConstructorInitializesTagToGivenValueWhenNotNullOrWhitespace() {
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar");
+    	assertEquals("foobar", instance.getTagFilter());
+    }
+    
     /**
      * Test of createValue method, of class GitParameterDefinition.
      */
@@ -77,7 +101,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         JSONObject jO = JSONObject.fromObject(jsonR);
         
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch");
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*");
        
         ParameterValue result = instance.createValue(request,jO);
         
@@ -103,7 +127,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testGetType() {
         System.out.println("Test of getType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch");
+        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*");
         String result = instance.getType();
         assertEquals(expResult, result);
         
@@ -121,7 +145,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testSetType() {
         System.out.println("Test of setType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch");
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*");
         
         instance.setType(expResult);        
         String result = instance.getType();        
@@ -136,7 +160,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch");       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*");       
         String result = instance.getDefaultValue();
         assertEquals(expResult, result);
     }
@@ -149,7 +173,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch");       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*");       
         instance.setDefaultValue(expResult);
         
         String result = instance.getDefaultValue();

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import net.sf.json.JSONObject;
+import net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition.SortMode;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -58,8 +59,8 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testCreateValue_StaplerRequest() {
         System.out.println("createValue");
               
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch", "*",true);
-       
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch", "*",GitParameterDefinition.SortMode.NONE);
+        
         StaplerRequest request = mock(StaplerRequest.class);
         ParameterValue result = instance.createValue(request);
         
@@ -68,33 +69,28 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenNull() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,true);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.NONE);
     	assertEquals("*", instance.getTagFilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ",true);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ",GitParameterDefinition.SortMode.NONE);
     	assertEquals("*", instance.getTagFilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenEmpty() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","",true);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","",GitParameterDefinition.SortMode.NONE);
     	assertEquals("*", instance.getTagFilter());
     }
     
     @Test
     public void testConstructorInitializesTagToGivenValueWhenNotNullOrWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar",true);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar",GitParameterDefinition.SortMode.NONE);
     	assertEquals("foobar", instance.getTagFilter());
     }
-    
-    @Test
-    public void testConstructorInitializesTagSplitterToValueWhenNotNullOrWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,true);
-    	assertTrue(instance.getUseSmartNumberSort());
-    }
+   
     
     @Test
     public void testSmartNumberStringComparerWorksWithSameNumberComponents() {
@@ -115,7 +111,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortEnabled() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,true);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.ASCENDING_SMART);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
@@ -134,7 +130,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     
     @Test
     public void testSortTagsYieldsCorrectOrderWithSmartSortDisabled() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,false);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,GitParameterDefinition.SortMode.ASCENDING);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
@@ -149,6 +145,33 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     	assertEquals("v_1.0.0.2", orderedTags.get(2));
     	assertEquals("v_1.0.0.5", orderedTags.get(3));
     	assertEquals("v_1.0.1.1", orderedTags.get(4));
+    }
+    
+    @Test
+    public void testSortMode_getIsUsingSmartSort() {
+    	assertFalse(SortMode.NONE.getIsUsingSmartSort());
+    	assertFalse(SortMode.ASCENDING.getIsUsingSmartSort());
+    	assertTrue(SortMode.ASCENDING_SMART.getIsUsingSmartSort());
+    	assertFalse(SortMode.DESCENDING.getIsUsingSmartSort());
+    	assertTrue(SortMode.DESCENDING_SMART.getIsUsingSmartSort());
+    }
+    
+    @Test
+    public void testSortMode_getIsDescending() {
+    	assertFalse(SortMode.NONE.getIsDescending());
+    	assertFalse(SortMode.ASCENDING.getIsDescending());
+    	assertFalse(SortMode.ASCENDING_SMART.getIsDescending());
+    	assertTrue(SortMode.DESCENDING.getIsDescending());
+    	assertTrue(SortMode.DESCENDING_SMART.getIsDescending());
+    }
+    
+    @Test
+    public void testSortMode_getIsSorting() {
+    	assertFalse(SortMode.NONE.getIsSorting());
+    	assertTrue(SortMode.ASCENDING.getIsSorting());
+    	assertTrue(SortMode.ASCENDING_SMART.getIsSorting());
+    	assertTrue(SortMode.DESCENDING.getIsSorting());
+    	assertTrue(SortMode.DESCENDING_SMART.getIsSorting());
     }
     
     /**
@@ -166,7 +189,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         JSONObject jO = JSONObject.fromObject(jsonR);
         
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",true);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
        
         ParameterValue result = instance.createValue(request,jO);
         
@@ -192,7 +215,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testGetType() {
         System.out.println("Test of getType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*",true);
+        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
         String result = instance.getType();
         assertEquals(expResult, result);
         
@@ -210,7 +233,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testSetType() {
         System.out.println("Test of setType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*",true);
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*",GitParameterDefinition.SortMode.NONE);
         
         instance.setType(expResult);        
         String result = instance.getType();        
@@ -225,7 +248,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*",true);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*",GitParameterDefinition.SortMode.NONE);       
         String result = instance.getDefaultValue();
         assertEquals(expResult, result);
     }
@@ -238,7 +261,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*",true);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*",GitParameterDefinition.SortMode.NONE);       
         instance.setDefaultValue(expResult);
         
         String result = instance.getDefaultValue();

--- a/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
+++ b/src/test/java/net/uaznia/lukanus/hudson/plugins/gitparameter/GitParameterDefinitionTest.java
@@ -58,7 +58,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testCreateValue_StaplerRequest() {
         System.out.println("createValue");
               
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch", "*",null);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch", "*",true);
        
         StaplerRequest request = mock(StaplerRequest.class);
         ParameterValue result = instance.createValue(request);
@@ -68,49 +68,37 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
 
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenNull() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,null);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,true);
     	assertEquals("*", instance.getTagFilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ",null);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","  ",true);
     	assertEquals("*", instance.getTagFilter());
     }
     
     @Test
     public void testConstructorInitializesTagFilterToAsteriskWhenEmpty() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","",null);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","",true);
     	assertEquals("*", instance.getTagFilter());
     }
     
     @Test
     public void testConstructorInitializesTagToGivenValueWhenNotNullOrWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar",null);
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","foobar",true);
     	assertEquals("foobar", instance.getTagFilter());
     }
     
     @Test
-    public void testConstructorInitializesTagSplitterToNullWhenEmpty() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,"");
-    	assertNull(instance.getTagPartSplitter());
-    }
-    
-    @Test
-    public void testConstructorInitializesTagSplitterToNullWhenWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,"  ");
-    	assertNull(instance.getTagPartSplitter());
-    }
-    
-    @Test
     public void testConstructorInitializesTagSplitterToValueWhenNotNullOrWhitespace() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,"foobar");
-    	assertEquals("foobar", instance.getTagPartSplitter());
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,true);
+    	assertTrue(instance.getUseSmartNumberSort());
     }
     
     @Test
-    public void testComponentStringComparerWorksWithSameNumberComponents() {
-    	Comparator<String> comparer = new GitParameterDefinition.ComponentStringComparer("\\.");
+    public void testSmartNumberStringComparerWorksWithSameNumberComponents() {
+    	Comparator<String> comparer = new GitParameterDefinition.SmartNumberStringComparer();
     	assertTrue(comparer.compare("v_1.1.0.2", "v_1.1.1.1") < 0);
     	assertTrue(comparer.compare("v_1.1.1.1", "v_1.1.1.1") == 0);
     	assertTrue(comparer.compare("v_1.1.1.1", "v_2.0.0.0") < 0);
@@ -118,28 +106,49 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     }
     
     @Test
-    public void testComponentStringComparerWorksWithDifferentNumberComponents() {
-    	Comparator<String> comparer = new GitParameterDefinition.ComponentStringComparer("\\.");
+    public void testSmartNumberStringComparerWorksWithDifferentNumberComponents() {
+    	Comparator<String> comparer = new GitParameterDefinition.SmartNumberStringComparer();
     	assertTrue(comparer.compare("v_1.1.1.1", "v_1.1.0") > 0);
     	assertTrue(comparer.compare("v_1.1.1.1", "v_1.1.2") < 0);
     	assertTrue(comparer.compare("v_1", "v_2.0.0.0") < 0);
     }
     
     @Test
-    public void testSortTagsYieldsCorrectOrder() {
-    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,"\\.");
+    public void testSortTagsYieldsCorrectOrderWithSmartSortEnabled() {
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,true);
     	Set<String> tags = new HashSet<String>();
     	tags.add("v_1.0.0.2");
     	tags.add("v_1.0.0.5");
     	tags.add("v_1.0.1.1");
     	tags.add("v_1.0.0.0");
+    	tags.add("v_1.0.0.10");
     	
-    	ArrayList<String> orderedTags = instance.sortTagNames(tags, instance.getTagPartSplitter());
+    	ArrayList<String> orderedTags = instance.sortTagNames(tags);
     	
     	assertEquals("v_1.0.0.0", orderedTags.get(0));
     	assertEquals("v_1.0.0.2", orderedTags.get(1));
     	assertEquals("v_1.0.0.5", orderedTags.get(2));
-    	assertEquals("v_1.0.1.1", orderedTags.get(3));
+    	assertEquals("v_1.0.0.10", orderedTags.get(3));
+    	assertEquals("v_1.0.1.1", orderedTags.get(4));
+    }
+    
+    @Test
+    public void testSortTagsYieldsCorrectOrderWithSmartSortDisabled() {
+    	GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch",null,false);
+    	Set<String> tags = new HashSet<String>();
+    	tags.add("v_1.0.0.2");
+    	tags.add("v_1.0.0.5");
+    	tags.add("v_1.0.1.1");
+    	tags.add("v_1.0.0.0");
+    	tags.add("v_1.0.0.10");
+    	
+    	ArrayList<String> orderedTags = instance.sortTagNames(tags);
+    	
+    	assertEquals("v_1.0.0.0", orderedTags.get(0));
+    	assertEquals("v_1.0.0.10", orderedTags.get(1));
+    	assertEquals("v_1.0.0.2", orderedTags.get(2));
+    	assertEquals("v_1.0.0.5", orderedTags.get(3));
+    	assertEquals("v_1.0.1.1", orderedTags.get(4));
     }
     
     /**
@@ -157,7 +166,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         JSONObject jO = JSONObject.fromObject(jsonR);
         
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",null);
+        GitParameterDefinition instance = new GitParameterDefinition("name","PT_REVISION","defaultValue","description","branch","*",true);
        
         ParameterValue result = instance.createValue(request,jO);
         
@@ -183,7 +192,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testGetType() {
         System.out.println("Test of getType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*",null);
+        GitParameterDefinition instance = new GitParameterDefinition("name",expResult,"defaultValue","description","branch","*",true);
         String result = instance.getType();
         assertEquals(expResult, result);
         
@@ -201,7 +210,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
     public void testSetType() {
         System.out.println("Test of setType method.");
         String expResult = "PT_REVISION";        
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*",null);
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf","defaultValue","description","branch","*",true);
         
         instance.setType(expResult);        
         String result = instance.getType();        
@@ -216,7 +225,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*",null);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", expResult,"description","branch","*",true);       
         String result = instance.getDefaultValue();
         assertEquals(expResult, result);
     }
@@ -229,7 +238,7 @@ public class GitParameterDefinitionTest extends HudsonTestCase  {
         System.out.println("getDefaultValue");
         String expResult = "defaultValue";
         
-        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*",null);       
+        GitParameterDefinition instance = new GitParameterDefinition("name","asdf", "other" ,"description","branch","*",true);       
         instance.setDefaultValue(expResult);
         
         String result = instance.getDefaultValue();


### PR DESCRIPTION
Hi.  In my fork of git-parameter I added an option called tagFilter that allows you to set the filter pattern for listing tags.  For example, if you're using tags of the form v:1.0.0.1234 to manage your releases and you don't want other tags to show up in the list, then you can set your tag filter to "v:*" and then only tags that have been intentionally setup to use the versioning convention will be displayed.
